### PR TITLE
fix: Исправление API endpoint - добавление префикса /v2

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,2 +1,2 @@
 
-NEXT_PUBLIC_API=https://api.upak.space
+NEXT_PUBLIC_API=https://api.upak.space/v2


### PR DESCRIPTION
## Описание проблемы
Бэкенд API работает на `https://api.upak.space/v2/*` (с префиксом `/v2`), но фронтенд был настроен на `https://api.upak.space` (без префикса). Из-за этого все запросы к API возвращали 404.

## Решение
Обновлена конфигурация в `.env.local`:
- **Было:** `NEXT_PUBLIC_API=https://api.upak.space`
- **Стало:** `NEXT_PUBLIC_API=https://api.upak.space/v2`

## Что изменено
- ✅ Файл `.env.local` - добавлен префикс `/v2` к API URL

## Следующие шаги
После мерджа этого PR необходимо обновить переменную окружения в Netlify:
1. Зайти в настройки проекта в Netlify
2. Перейти в раздел Environment Variables
3. Обновить `NEXT_PUBLIC_API` на `https://api.upak.space/v2`
4. Пересобрать проект