### PR TITLE
Добавлена кнопка входа в шапку сайта

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -112,14 +112,9 @@ export function Header() {
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
-            <div className="flex items-center space-x-2">
-              <Button asChild variant="ghost">
-                <Link href="/auth/signin">Войти</Link>
-              </Button>
-              <Button asChild>
-                <Link href="/auth/signup">Регистрация</Link>
-              </Button>
-            </div>
+            <Button asChild variant="default">
+              <Link href="/login">Войти</Link>
+            </Button>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Описание изменений

Добавлена кнопка "Войти" в шапку сайта, которая ведет на страницу `/login`.

### Что было сделано:
- ✅ Изменена ссылка кнопки "Войти" с `/auth/signin` на `/login`
- ✅ Упрощен интерфейс: убрана кнопка регистрации, оставлена только кнопка входа
- ✅ Для авторизованных пользователей отображается выпадающее меню с пунктом "Личный кабинет"
- ✅ Кнопка стилизована в соответствии с дизайном сайта

### Поведение:
- **Неавторизованный пользователь**: видит кнопку "Войти", которая ведет на `/login`
- **Авторизованный пользователь**: видит аватар с выпадающим меню, где есть пункт "Личный кабинет"

### Измененные файлы:
- `components/header.tsx`

Closes #issue (если есть связанная задача)