### PR TITLE
feat(auth): Переход на httpOnly cookies для безопасной аутентификации

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,7 +3,6 @@
 
 import { useEffect, useState } from 'react';
 import { fetchAuthJSON, API_BASE } from '@/lib/api';
-import { authHeader } from '@/lib/auth';
 
 type Me = {
   email: string;
@@ -19,7 +18,7 @@ export default function DashboardPage() {
 
   async function load() {
     try {
-      const data = await fetchAuthJSON<Me>('/me');
+      const data = await fetchAuthJSON<Me>('/v2/me');
       setMe(data);
     } catch (e: any) {
       setErr(e.message || 'Ошибка загрузки');
@@ -32,9 +31,10 @@ export default function DashboardPage() {
   async function buy(pkg:'start'|'pro') {
     setErr(null);
     try {
-      const res = await fetch(`${API_BASE}/payments/create`, {
+      const res = await fetch(`${API_BASE}/v2/payments/create`, {
         method:'POST',
-        headers:{ 'Content-Type':'application/json', ...authHeader() },
+        credentials: 'include', // Добавлено: отправка httpOnly cookies
+        headers:{ 'Content-Type':'application/json' },
         body: JSON.stringify({ package: pkg })
       });
       if (!res.ok) throw new Error(await res.text());

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,7 +3,6 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { setToken } from '@/lib/auth';
 import { API_BASE } from '@/lib/api';
 
 export default function LoginPage() {
@@ -15,17 +14,21 @@ export default function LoginPage() {
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setErr(null); setLoading(true);
+    setErr(null); 
+    setLoading(true);
     try {
       const body = new URLSearchParams({ username: email, password });
-      const res = await fetch(`${API_BASE}/auth/token`, {
+      const res = await fetch(`${API_BASE}/v2/auth/token`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        credentials: 'include', // Важно: получаем httpOnly cookie от сервера
         body
       });
+      
       if (!res.ok) throw new Error('Неверный e-mail или пароль');
-      const { access_token } = await res.json();
-      setToken(access_token);
+      
+      // Токен теперь в httpOnly cookie, не нужно сохранять в localStorage
+      // Просто перенаправляем на dashboard
       r.push('/dashboard');
     } catch (e: any) {
       setErr(e.message || 'Ошибка входа');

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -10,6 +10,7 @@ class ApiClient {
   ): Promise<BackendApiResponse<T>> {
     try {
       const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+        credentials: 'include', // Добавлено: отправка httpOnly cookies
         headers: {
           'Content-Type': 'application/json',
           ...options.headers,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,20 +1,31 @@
 
 // lib/auth.ts
-export const TOKEN_KEY = 'upak_token';
 
-export function getToken(): string | null {
-  try { return localStorage.getItem(TOKEN_KEY); } catch { return null; }
+/**
+ * Проверяет авторизацию пользователя через запрос к /v2/me
+ * Токен теперь хранится в httpOnly cookie, поэтому не доступен из JavaScript
+ */
+export async function checkAuth(): Promise<boolean> {
+  try {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API || 'http://localhost:8000'}/v2/me`, {
+      credentials: 'include', // Важно: отправляет cookies
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
 }
 
-export function setToken(token: string) {
-  try { localStorage.setItem(TOKEN_KEY, token); } catch {}
-}
-
-export function clearToken() {
-  try { localStorage.removeItem(TOKEN_KEY); } catch {}
-}
-
-export function authHeader() {
-  const t = getToken();
-  return t ? { Authorization: `Bearer ${t}` } : {};
+/**
+ * Выход из системы - удаляет httpOnly cookie на сервере
+ */
+export async function logout(): Promise<void> {
+  try {
+    await fetch(`${process.env.NEXT_PUBLIC_API || 'http://localhost:8000'}/v2/auth/logout`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+  } catch (e) {
+    console.error('Logout error:', e);
+  }
 }


### PR DESCRIPTION
## 🔐 Описание изменений

Переделана система аутентификации с использования `localStorage` на безопасные `httpOnly cookies`.

### ✅ Что сделано на фронтенде:

#### 1. **lib/auth.ts** - полностью переработан
- ❌ Удалены функции работы с localStorage: `getToken()`, `setToken()`, `clearToken()`, `authHeader()`
- ✅ Добавлена `checkAuth()` - проверка авторизации через запрос к `/v2/me`
- ✅ Добавлена `logout()` - выход из системы через `/v2/auth/logout`

#### 2. **lib/api.ts** - обновлена логика запросов
- ❌ Убрано добавление `Authorization` header
- ✅ Добавлен `credentials: 'include'` во все fetch запросы
- ✅ При 401 ошибке автоматическое перенаправление на `/login`

#### 3. **lib/api-client.ts** - добавлена поддержка cookies
- ✅ Добавлен `credentials: 'include'` во все запросы

#### 4. **app/login/page.tsx** - обновлен процесс логина
- ❌ Убрано сохранение токена в localStorage
- ✅ Добавлен `credentials: 'include'` для получения cookie от сервера
- ✅ Обновлен путь API: `/auth/token` → `/v2/auth/token`

#### 5. **app/dashboard/layout.tsx** - новая логика проверки авторизации
- ❌ Убрана проверка токена из localStorage
- ✅ Проверка авторизации через `checkAuth()` (запрос к `/v2/me`)
- ✅ Добавлен индикатор загрузки при проверке
- ✅ Обновлена функция выхода с использованием `logout()`

#### 6. **app/dashboard/page.tsx** - обновлены API запросы
- ✅ Добавлен `credentials: 'include'` в fetch запросы
- ✅ Обновлены пути API: `/me` → `/v2/me`, `/payments/create` → `/v2/payments/create`

---

## ⚠️ Требуется обновление бэкенда

Для полной работы этих изменений необходимо обновить бэкенд:

### 1. **POST /v2/auth/token**
```python
# Вместо возврата токена в JSON
response.set_cookie(
    key="access_token",
    value=token,
    httponly=True,
    secure=True,  # только для HTTPS
    samesite='lax',
    max_age=3600 * 24 * 7  # 7 дней
)
```

### 2. **Middleware для чтения токена**
```python
# Читать токен из cookies вместо Authorization header
token = request.cookies.get("access_token")
```

### 3. **POST /v2/auth/logout**
```python
# Удаление cookie
response.delete_cookie("access_token")
```

### 4. **CORS настройки**
```python
# Разрешить отправку credentials
allow_credentials=True
allow_origins=["http://localhost:3000", "https://upak.space"]
```

---

## 🔒 Преимущества безопасности

- ✅ **Защита от XSS**: токен недоступен для JavaScript
- ✅ **Автоматическая отправка**: браузер автоматически отправляет cookie
- ✅ **Secure flag**: cookie передается только по HTTPS (в продакшене)
- ✅ **SameSite**: защита от CSRF атак

---

## 📝 Тестирование

После обновления бэкенда необходимо протестировать:
1. ✅ Вход в систему
2. ✅ Проверка авторизации при переходе на `/dashboard`
3. ✅ Работа всех API запросов с cookies
4. ✅ Выход из системы
5. ✅ Автоматическое перенаправление на `/login` при истечении токена

---

## 🔗 Связанные задачи

- Обновление бэкенда на сервере 51.250.110.59
- Настройка CORS для работы с credentials
- Тестирование в production окружении