### PR TITLE
Fix: Netlify build error - wrap useSearchParams in Suspense boundary

### DIFF
--- a/app/payment/success/page.tsx
+++ b/app/payment/success/page.tsx
@@ -1,7 +1,7 @@
 
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { fetchAuthJSON } from '@/lib/api';
 
@@ -12,7 +12,7 @@ type PaymentStatus = {
   cards_limit: number | null;
 };
 
-export default function PaymentSuccessPage() {
+function PaymentSuccessContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [loading, setLoading] = useState(true);
@@ -177,5 +177,20 @@ export default function PaymentSuccessPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function PaymentSuccessPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-green-50 via-white to-blue-50">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-green-600 mx-auto mb-4"></div>
+          <p className="text-lg text-gray-700">Загрузка...</p>
+        </div>
+      </div>
+    }>
+      <PaymentSuccessContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## 🐛 Исправление ошибки деплоя на Netlify

### Проблема
Деплой на Netlify падал с ошибкой:
```
useSearchParams() should be wrapped in a suspense boundary at page "/payment/success"
Error occurred prerendering page "/payment/success"
```

### Решение
✅ Обернул компонент `PaymentSuccessContent`, использующий `useSearchParams()`, в `Suspense` boundary  
✅ Добавил fallback с индикатором загрузки для лучшего UX  
✅ Локальная сборка проходит успешно - все 14 страниц сгенерированы без ошибок

### Изменения
- **Файл**: `app/payment/success/page.tsx`
- Переименовал основной компонент в `PaymentSuccessContent`
- Добавил импорт `Suspense` из React
- Создал новый экспортируемый компонент `PaymentSuccessPage` с Suspense wrapper
- Добавил красивый fallback UI с анимацией загрузки

### Тестирование
✅ Локальная сборка: `npm run build` - успешно  
✅ Все 14 страниц сгенерированы статически  
✅ Нет ошибок TypeScript или ESLint

### Netlify
После мержа этого PR, Netlify автоматически запустит новый деплой, который должен пройти успешно.

---
**Важно**: Не мержить автоматически - дождаться проверки Netlify deploy preview!